### PR TITLE
Removes qemu installation from install_deps

### DIFF
--- a/assets/scripts/install_deps.sh
+++ b/assets/scripts/install_deps.sh
@@ -117,9 +117,6 @@ sudo -u ubuntu rosdep update
 
 $(aws ecr get-login --no-include-email --registry-ids 593875212637 --region us-east-1)
 
-#Install Ubuntu dependencies for cross compilation:
-apt update &&  apt install -y qemu-user-static
-
 #Build Docker Container
 echo "Building docker image for robot ..."
 docker build -t jetbot-ros -f Dockerfile .

--- a/assets/scripts/install_qemu.sh
+++ b/assets/scripts/install_qemu.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/bash
 
-#Install Ubuntu dependencies for cross compilation:
+# Install Ubuntu dependencies for cross compilation:
 apt update -y && apt install -y qemu-user-static
 

--- a/assets/scripts/install_qemu.sh
+++ b/assets/scripts/install_qemu.sh
@@ -1,0 +1,5 @@
+#! /usr/bin/bash
+
+#Install Ubuntu dependencies for cross compilation:
+apt update -y && apt install -y qemu-user-static
+


### PR DESCRIPTION
This PR removes the installation of the qemu-static package from the `install_dep.sh` script.  While this step is still needed in the installation process, the intention here is to isolate the step to ensure it runs independently without issue.