### PR TITLE
ROLE_ARN is exported as variable from CloudFormation bootstrap template

### DIFF
--- a/assets/scripts/install_deps.sh
+++ b/assets/scripts/install_deps.sh
@@ -44,9 +44,8 @@ aws iot describe-endpoint \
 
 #Update roboMakerSettings file
 echo "Updating roboMakerSettings.json ..."
-ROLE_ARN=${ROLE_ARN/\//\\\/}
 sed -i "s/<Update S3 Bucketname Here>/$BUCKET_NAME/g" $ROBOMAKERFILE
-sed -i "s/<Update IAM Role ARN Here>/$ROLE_ARN/g" $ROBOMAKERFILE
+sed -i "s|<Update IAM Role ARN Here>|$ROLE_ARN|g" $ROBOMAKERFILE
 sed -i "s/<Update IoT Endpoint Here>/$IOTENDPOINT/g" $ROBOMAKERFILE
 sed -i "s/<Update Public Subnet 1 Here>/$SUBNET1/g" $ROBOMAKERFILE
 sed -i "s/<Update Public Subnet 2 Here>/$SUBNET2/g" $ROBOMAKERFILE


### PR DESCRIPTION
Presently `iamRole` does not get populated in **roboMakerSettings.json** when running the install script. 

`ROLE_ARN` is already exported as a variable in https://github.com/jerwallace/aws-robomaker-workshops/blob/master/static/cfn/bootstrap.cfn.yaml which is similar to **bootstrap.rover.cfn.yaml** in the same repository, does not export `ROLE_ARN` and is what's linked to in the "Launch Stack" in the Cloud Robotics workshop. 

The fix for this is the change proposed in this PR along with using **bootstrap.cfn.yaml** for the initial setup template, I have tested both as working. 
