### PR TITLE
fixed export of ARN role

### DIFF
--- a/assets/scripts/install_deps.sh
+++ b/assets/scripts/install_deps.sh
@@ -44,9 +44,8 @@ aws iot describe-endpoint \
 
 #Update roboMakerSettings file
 echo "Updating roboMakerSettings.json ..."
-ROLE_ARN=${ROLE_ARN/\//\\\/}
 sed -i "s/<Update S3 Bucketname Here>/$BUCKET_NAME/g" $ROBOMAKERFILE
-sed -i "s/<Update IAM Role ARN Here>/$ROLE_ARN/g" $ROBOMAKERFILE
+sed -i "s|<Update IAM Role ARN Here>|$ARN_SIM_ROLE|g" $ROBOMAKERFILE
 sed -i "s/<Update IoT Endpoint Here>/$IOTENDPOINT/g" $ROBOMAKERFILE
 sed -i "s/<Update Public Subnet 1 Here>/$SUBNET1/g" $ROBOMAKERFILE
 sed -i "s/<Update Public Subnet 2 Here>/$SUBNET2/g" $ROBOMAKERFILE


### PR DESCRIPTION
This properly replaces the templated string with the right ARN for simulations.

This PR goes along with a change to the CF template, adding the following to output SubmitJobSH:

export ARN_SIM_ROLE="${RoboMakerSimulationRole.Arn}"
export ARN_DEP_ROLE="${RoboMakerDeploymentRole.Arn}"
